### PR TITLE
Use ruby/setup-ruby@v1.90.0 instead of deprecated actions/setup-ruby

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Ruby 2.6
+      - name: Setup Ruby 2.6.9
         uses: ruby/setup-ruby@v1.90.0
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.6.9
 
       - name: Add Gemfile
         run: |
@@ -42,10 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Ruby 2.6
+      - name: Setup Ruby 2.6.9
         uses: ruby/setup-ruby@v1.90.0
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.6.9
 
       - name: Add ~/.gemrc
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.90.0
         with:
           ruby-version: 2.6.x
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.90.0
         with:
           ruby-version: 2.6.x
 


### PR DESCRIPTION
`actions/setup-ruby` is no longer being maintained. Change to use `ruby/setup-ruby@v1.90.0` instead.